### PR TITLE
Add support for heredoc/nowdoc, new tokens, and advanced PHP constructs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,93 +73,113 @@ cargo check --workspace
 cargo test --workspace
 ```
 
-## 📋 Current Capacity
+## 📋 Current Capacity (Updated)
 
-### ✅ **Fully Implemented & Tested**
-#### **Lexical Analysis (php-lexer)**
+### ✅ **Implemented (Phase 1 Core + Recent Extensions)**
+#### **Lexical Analysis (`php-lexer`)**
 * ✅ PHP Tags: `<?php`, `?>`
-* ✅ Variables: `$variable`
-* ✅ Literals: Numbers (int/float), strings ("double" with interpolation, 'single')
-* ✅ Operators: Arithmetic `+ - * /`, comparison `< > <= >= == !=`, assignment `=`, concatenation `.`, increment/decrement `++ --`, null coalescing `??`
-* ✅ Keywords: `echo`, `print`, `if`, `else`, `elseif`, `while`, `for`, `foreach`, `switch`, `case`, `default`, `break`, `continue`, `function`, `return`, `true`, `false`, `null`
-* ✅ Punctuation: `; , ( ) { } [ ] =>`
-* ✅ Comments: `//`, `#`, `/* */`
+* ✅ Variables & identifiers
+* ✅ Literals: integers, floats, single & double quoted strings, nowdoc/ heredoc (basic)
+* ✅ Operators: arithmetic `+ - * /`, comparison `< > <= >= == != <=>`, bitwise `& |`, concatenation `.`, assignment `=`, null coalescing `??`, null coalescing assignment `??=`, increment/decrement `++ --`
+* ✅ Logical tokens: `and` / `or` keywords (runtime truthiness implemented) – symbolic `&& || !` still pending
+* ✅ Punctuation & structure: `; , ( ) { } [ ] => :`
+* ✅ Keywords / Control: `if else elseif while for foreach switch case default break continue function return match yield static`
+* ✅ Comments: `//` `#` `/* ... */`
 
-#### **Syntax Parsing (php-parser)**
-* ✅ Expressions: Precedence climbing (handles `2 + 3 * 4` correctly)
-* ✅ Array Literals: `[1, 2, "a" => 3]`
-* ✅ Array Access Chains: `$arr[0]["key"]`
-* ✅ Assignments & Echo/Print
-* ✅ Control Flow: `if / elseif / else`, `while`, `for(init;cond;inc)`, `foreach ($arr as $v)` & `foreach ($arr as $k => $v)`
-* ✅ Switch/Case/Default with break handling
-* ✅ Function Definitions & Calls (positional params)
-* ✅ Constants: `define("NAME", value)` and `const NAME = value;`
-* ✅ Null Coalescing: `$a ?? $b`
-* ✅ Postfix Increment/Decrement parsing
-* ✅ String Interpolation Support (parsed as plain strings; interpolation applied at runtime)
-* ✅ AST kept pure (no execution logic)
+#### **Syntax Parsing (`php-parser`)**
+* ✅ Precedence–climbing expression parser (correct grouping like `2 + 3 * 4`)
+* ✅ Arrays (numeric & associative) including keyed elements and auto‑indexing
+* ✅ Array access & nested chains `$a[0]["k"]`
+* ✅ Assignments, null‑coalesce assignment `??=`
+* ✅ Destructuring assignment basic form (`[a, 'k' => b] = ...`)
+* ✅ Control flow: `if/elseif/else`, `while`, `for`, `foreach (value / key=>value)`, `switch` / `case` / `default`
+* ✅ `match` expression (PHP 8 style)
+* ✅ Ternary operator `?:`
+* ✅ Function definitions (positional params) & calls
+* ✅ Static variable declarations inside functions
+* ✅ Closures / arrow functions placeholder representation
+* ✅ `yield` expression (semantic placeholder)
+* ✅ Postfix & prefix `++ --`
+* ✅ String interpolation kept AST‑agnostic (runtime interpolation)
 
-#### **Runtime (php-runtime)**
-* ✅ Variable storage and lookup (undefined vars => `null` behavior)
-* ✅ Constant definition storage
-* ✅ Expression evaluation: arithmetic, comparison, concatenation, null coalescing
-* ✅ Control flow execution: if/else, while, for, foreach, switch (with break/continue)
-* ✅ Function invocation (user-defined) with isolated scope & simple return handling
-* ✅ Arrays: indexed & associative insert, access, auto-increment keys
-* ✅ Array access evaluation with graceful `null` on missing index
-* ✅ Superglobal bootstrap (minimal `$_GET` placeholder)
-* ✅ Postfix `++` / `--` semantics
-* ✅ Simple double-quoted string variable interpolation
+#### **Runtime (`php-runtime`)**
+* ✅ Variable, constant, and (user) function symbol tables
+* ✅ Control flow execution with proper break / continue propagation
+* ✅ Arithmetic, comparison, concatenation, bitwise, logical (keyword) operators
+* ✅ Null coalescing + coalescing assignment, ternary, match evaluation
+* ✅ Static variables with per‑function persistence
+* ✅ Destructuring assignment handling (array + keyed targets)
+* ✅ Arrays: push, associative insert, integer & string key access, tolerant missing / non‑array access returns `null`
+* ✅ Basic closures (stored by generated id) & dynamic invocation placeholder
+* ✅ Output buffering stack (`ob_start`, `ob_get_clean`) and direct write fallback
+* ✅ Simple string interpolation (variable tokens only)
+* ✅ Preliminary built‑ins (see below)
+
+#### **Built‑ins / Utility Implemented (Provisional)**
+| Category | Functions / Features |
+|----------|----------------------|
+| Env / System | `getenv` |
+| Arrays | `array_merge`, `array_sum`, `usort` (simplified comparator), `iterator_to_array`, `implode`, destructuring |
+| Strings / Formatting | `str_repeat`, `printf` (subset `%s %d %f`), interpolation, heredoc/nowdoc pass‑through |
+| JSON | `json_encode` (basic flags: unescaped slashes/unicode), `json_decode` (assoc arrays) |
+| Regex | `preg_match` (basic, no pattern modifiers beyond delimiters) |
+| Filters | `filter_var` (`FILTER_VALIDATE_INT`) + constants bootstrap |
+| Parsing | `parse_str` |
+| Flow / Info | `isset`, `define`, `set_error_handler` (stub) |
+| Buffering | `ob_start`, `ob_get_clean` |
+
+> Note: Implementations prioritize functional bootstrapping over strict edge‑case parity. Error / warning behaviors are intentionally lenient (no E_NOTICE / E_WARNING yet).
 
 #### **Testing & Tooling**
-* ✅ Organized integration tests & PHP file based scenarios
-* ✅ Debug utilities (token dump earlier used; now cleaned)
-* ✅ Modular crate boundaries respected
-* ✅ Build & test scripts (`scripts/test_all.sh`)
+* ✅  Multi‑crate integration tests & PHP file scenarios
+* ✅  Script runner + release binary parity verified
+* ✅  Debug / inspection utilities (token inspection previously) 
+* ✅  CI‑friendly workspace scripts (`scripts/test_all.sh`)
 
-#### **Recently Added (Since Initial README Draft)**
-> Arrays, array access, foreach, for loops, switch/case/default, break/continue control flow signals, user functions, null coalescing, string interpolation, postfix inc/dec.
+### 🆕 Recently Added (This Iteration Cycle)
+`match`, `ternary`, null‑coalescing assignment, static vars, destructuring assignment, basic closures / dynamic call placeholder, output buffering, JSON encode/decode, regex (`preg_match`), filtering (`filter_var` int), environment access (`getenv`), formatting (`printf`), array utilities (`array_merge`, `array_sum`, `usort`, `implode`), parsing utilities (`parse_str`).
 
-### 🚧 **In Active Development**
-* Enriched Runtime semantics (logical operators & strict comparisons upcoming)
-* Type System refinements (truthiness & coercions expansion)
-* Enhanced Error Reporting (line/column propagation across crates)
-* Standard Library bootstrap (planned migration of built-ins like `count`, `strlen`)
+### 🚧 In Active Development
+* Comparator & true closure value type (replace string id hack)
+* Generator semantics (current `yield` is a no‑op placeholder)
+* Enhanced error reporting (line/column propagation)
+* Strict comparisons + logical operator symbols (`===`, `!==`, `&&`, `||`, `!`)
+* Try / catch / finally execution semantics (parser groundwork partially present elsewhere)
 
-### 📅 **Planned Features** (see [ROADMAP.md](ROADMAP.md))
-* Advanced Control Flow: try/catch/finally, ternary `?:`, Elvis `?:` nuance, match (PHP 8)
-* Object-Oriented Programming: classes, interfaces, traits, visibility, static
-* Functions: default params, variadics, by-reference params, closures/anonymous functions
-* Strict & Identity Comparisons: `===`, `!==`
-* Logical Operators: `&&`, `||`, `!`
-* Remaining Operators: modulo `%`, assignment compound ops `+= -= *= .=`
-* Arrays: spread, nested destructuring (later phase), by-reference foreach
-* Standard Library: Core PHP 8.x coverage
-* Web Server Integration: basic SAPI simulation & request globals population
-* Extension System: FFI layer & dynamic loading
-* Error Handling: exceptions, stack traces
-* Performance: opcode-like intermediate representation (future optimization phase)
+### 📅 Planned / Upcoming (excerpt – see [ROADMAP.md](ROADMAP.md))
+* Full logical & identity operators
+* Compound assignments (`+= -= *= /= .=` etc.) & modulo `%`
+* Function features: default args, variadics, by‑reference params, proper closures with captured environment
+* Improved interpolation (`{"expr"}` forms)
+* Exceptions & stack traces
+* Object model: classes, properties, methods, visibility, traits, interfaces
+* Array spread, by‑reference foreach, advanced destructuring
+* Standard library expansion / namespacing
+* Performance layer (IR / opcode optimization)
+* Extension / FFI bridge & web SAPI harness
 
-### ⚠️ Current Limitations
+### ⚠️ Current Limitations (Updated)
 | Area | Missing / Partial |
 |------|-------------------|
-| Operators | `===`, `!==`, `%`, `&&`, `||`, `!`, compound assignments, ternary `?:` |
-| Types | Objects (stub only), resources (placeholder), no references | 
-| Functions | No default params, no closures, no variadics, no recursion tests yet |
-| Arrays | No nested modification semantics (write-through on access), no spread, no unset | 
-| Strings | Interpolation is simple (no complex `{}` or array deref) |
-| Error Handling | No exceptions, minimal error context | 
-| OOP | Classes/interfaces/traits not executed (parsing not yet started) |
-| Stdlib | Built-ins not yet implemented beyond `define` handling | 
-| I/O | No file/network APIs | 
-| Security | No sandboxing / open_basedir equivalents |
+| Operators | `===`, `!==`, `%`, `&&`, `||`, `!`, compound assignments, modulo, bitwise XOR, shifts |
+| Generators | `yield` returns `null` (no generator objects / iteration) |
+| Closures | Stored as string ids (no captured lexical environment) |
+| Functions | No default params, variadics, by‑ref params, user recursion untested edge cases |
+| Arrays | No spread, unset, reference semantics, stable order for json/object decode only basic |
+| JSON | Flags incomplete (only partial unescaped handling) & error modes ignored |
+| Regex | No modifiers (`i`, `m`, etc.) and limited delimiter support (`/`) |
+| Filtering | Only `FILTER_VALIDATE_INT` implemented (email, url pending) |
+| Error Handling | No exceptions, silent instead of notices/warnings |
+| OOP | Not started (parsing & runtime) |
+| Security | No sandboxing, no resource limits |
+| Performance | No JIT / IR; naive evaluation model |
 
-### 🔍 Near-Term Focus (Next Iteration Targets)
-1. Logical operators & strict comparison tokens
-2. Modulo operator end-to-end
-3. Ternary conditional expression parsing/execution
-4. Function return value propagation refinements & early `return` inside nested blocks
-5. Basic exception scaffolding (enum + placeholder throw)
+### 🔍 Near-Term Focus
+1. Introduce a `PhpValue::Closure` with captured environment & real callable invocation
+2. Implement identity / logical operator symbols & strict comparison semantics
+3. Add `FILTER_VALIDATE_EMAIL` & basic validator framework
+4. Generator model (collect yielded values or iterator abstraction)
+5. Exception enum + minimal `throw` / `try/finally` runtime execution
 
 ## 🧪 Examples
 

--- a/crates/php-lexer/src/lexer/keywords.rs
+++ b/crates/php-lexer/src/lexer/keywords.rs
@@ -48,6 +48,9 @@ impl KeywordHandler {
         keywords.insert("break", Token::Break);
         keywords.insert("continue", Token::Continue);
         keywords.insert("do", Token::Do);
+    keywords.insert("declare", Token::Declare);
+        keywords.insert("try", Token::Try);
+        keywords.insert("catch", Token::Catch);
         
         // Built-in functions
         keywords.insert("print_r", Token::PrintR);

--- a/crates/php-lexer/src/lexer/literals.rs
+++ b/crates/php-lexer/src/lexer/literals.rs
@@ -55,4 +55,107 @@ impl LiteralHandler {
     pub fn tokenize_identifier(stream: &mut CharStream) -> String {
         stream.read_identifier()
     }
+
+    /// Tokenize a heredoc or nowdoc string literal beginning with <<<
+    /// Basic implementation: captures content until a line that exactly matches the identifier
+    /// (optionally followed by a semicolon). Nowdoc (with single quotes) is treated the same as
+    /// heredoc for now (no special interpolation differences at lexing stage in this simplified engine).
+    pub fn tokenize_heredoc(stream: &mut CharStream) -> LexResult<Token> {
+        // We are positioned at first '<' of the sequence '<<<'
+        // Consume the three '<'
+        stream.next();
+        stream.next();
+        stream.next();
+
+        // Detect nowdoc vs heredoc (nowdoc starts with single quote)
+        let mut identifier = String::new();
+        let mut nowdoc = false;
+        if let Some(&ch) = stream.peek() {
+            if ch == '\'' { // nowdoc
+                nowdoc = true;
+                stream.next(); // consume opening quote
+                while let Some(&c2) = stream.peek() {
+                    if c2 == '\'' { stream.next(); break; }
+                    if c2 == '\n' || c2 == '\r' { break; }
+                    identifier.push(stream.next().unwrap());
+                }
+            } else {
+                while let Some(&c2) = stream.peek() {
+                    if c2 == '\n' || c2 == '\r' { break; }
+                    if c2.is_whitespace() { break; }
+                    identifier.push(stream.next().unwrap());
+                }
+            }
+        }
+
+        // Consume remainder of the line (up to and including first newline)
+        while let Some(ch) = stream.next() {
+            if ch == '\n' { break; }
+            if ch == '\r' { // handle Windows newlines \r\n
+                if let Some(&'\n') = stream.peek() { stream.next(); }
+                break;
+            }
+        }
+
+        if identifier.is_empty() {
+            let pos = stream.position();
+            return Err(LexError::UnterminatedString { line: pos.line, column: pos.column });
+        }
+
+        // Accumulate lines until a line that is exactly identifier or identifier; (with optional trailing whitespace)
+        let mut content = String::new();
+        let mut current_line = String::new();
+    // Track if terminator had trailing semicolon (currently unused; parser tolerates missing semicolon after heredoc assignment)
+    let mut _had_trailing_semicolon = false;
+        loop {
+            let ch_opt = stream.next();
+            match ch_opt {
+                Some('\n') => {
+                    // Check termination condition on current_line without trailing whitespace
+                    let trimmed = current_line.trim_end();
+                    if trimmed == identifier || trimmed == format!("{};", identifier) {
+                        if trimmed.ends_with(';') { _had_trailing_semicolon = true; }
+                        // Heredoc terminator found - do not include terminator line
+                        break;
+                    } else {
+                        content.push_str(&current_line);
+                        content.push('\n');
+                        current_line.clear();
+                    }
+                }
+                Some('\r') => {
+                    // Normalize CR or CRLF as newline
+                    if let Some(&'\n') = stream.peek() { stream.next(); }
+                    let trimmed = current_line.trim_end();
+                    if trimmed == identifier || trimmed == format!("{};", identifier) {
+                        if trimmed.ends_with(';') { _had_trailing_semicolon = true; }
+                        break;
+                    } else {
+                        content.push_str(&current_line);
+                        content.push('\n');
+                        current_line.clear();
+                    }
+                }
+                Some(ch) => {
+                    current_line.push(ch);
+                }
+                None => {
+                    // EOF without terminator
+                    let pos = stream.position();
+                    return Err(LexError::UnterminatedString { line: pos.line, column: pos.column });
+                }
+            }
+        }
+
+        // For nowdoc we don't perform interpolation at lexer stage; runtime will treat raw string
+        let _ = nowdoc; // suppress unused warning for now
+        // If a semicolon followed the terminator, emit a semicolon token next by pushing it back conceptually.
+        // Since we don't have a pushback mechanism, we'll store the fact in a thread-local? Simpler: append ';' to content? Not correct.
+        // Instead: we will include a trailing semicolon token by hacking: place a sentinel in stream that the main lexer will detect.
+        // Minimal approach: if had_trailing_semicolon, we append a ';' char to stream at current position by manipulating internal buffer.
+        // Simpler: return String token; main lexer after calling this will check last consumed line? For now, ignore emitting semicolon and rely on parser not requiring it.
+        // However parser currently expects semicolon after assignment. We'll fake by appending an actual semicolon token via a global flag (out of scope). So fallback: ensure upstream code doesn't require semicolon by adding one at end of content? This changes string value; unacceptable.
+        // Revised simpler solution: Do nothing extra; adjust parser to accept missing semicolon after heredoc assignment.
+        Ok(Token::String(content))
+    }
 }

--- a/crates/php-lexer/src/lexer/operators.rs
+++ b/crates/php-lexer/src/lexer/operators.rs
@@ -32,13 +32,15 @@ impl OperatorHandler {
     /// Tokenize less than or less or equal
     pub fn tokenize_less_than(stream: &mut CharStream) -> LexResult<Token> {
         stream.next(); // consume '<'
-        
         if let Some(&'=') = stream.peek() {
             stream.next(); // consume '='
-            Ok(Token::LessOrEqual)
-        } else {
-            Ok(Token::LessThan)
+            if let Some(&'>') = stream.peek() {
+                stream.next(); // consume '>'
+                return Ok(Token::Spaceship);
+            }
+            return Ok(Token::LessOrEqual);
         }
+        Ok(Token::LessThan)
     }
 
     /// Tokenize greater than or greater or equal

--- a/crates/php-lexer/src/stream.rs
+++ b/crates/php-lexer/src/stream.rs
@@ -31,6 +31,19 @@ pub struct CharStream<'a> {
     position: Position,
 }
 
+impl<'a> Clone for CharStream<'a> {
+    fn clone(&self) -> Self {
+        // NOTE: We cannot clone the internal iterator state exactly without storing the original slice & offset.
+        // For the limited heuristic in the lexer (one-char lookahead already exists), we avoid deep clone usage now.
+        // If clone is requested, we create a new empty-at-end stream to prevent misuse.
+        // Future improvement: refactor CharStream to store original & index to enable true cloning.
+        Self {
+            chars: "".chars().peekable(),
+            position: self.position,
+        }
+    }
+}
+
 impl<'a> CharStream<'a> {
     /// Create a new character stream from input string
     pub fn new(input: &'a str) -> Self {

--- a/crates/php-lexer/src/token.rs
+++ b/crates/php-lexer/src/token.rs
@@ -42,6 +42,9 @@ pub enum Token {
     Break,
     Continue,
     Do,
+    Declare,
+    Try,
+    Catch,
     
     // Built-in functions (will move to stdlib later)
     PrintR,
@@ -71,6 +74,8 @@ pub enum Token {
     GreaterThan,
     LessOrEqual,
     GreaterOrEqual,
+    /// Spaceship operator <=>
+    Spaceship,
     Plus,
     Minus,
     Multiply,
@@ -81,6 +86,20 @@ pub enum Token {
     NullCoalescing, // ??
     Increment, // ++
     Decrement, // --
+    /// Error suppression operator '@' (currently ignored by runtime)
+    At,
+    /// Ampersand '&' (reference / bitwise AND placeholder)
+    Ampersand,
+    /// Object operator '->'
+    ObjectOperator,
+    /// Pipe '|' for union types (currently skipped by parser)
+    Pipe,
+    /// Logical AND '&&'
+    LogicalAnd,
+    /// Logical OR '||'
+    LogicalOr,
+    /// Ellipsis '...' for variadics/spread (currently skipped by parser)
+    Ellipsis,
     
     // Punctuation
     Semicolon,
@@ -106,7 +125,8 @@ impl Token {
             Token::Public | Token::Private | Token::Protected | Token::Static |
             Token::Var | Token::Const | Token::True | Token::False | Token::Null |
             Token::Isset | Token::Empty | Token::Switch | Token::Case |
-            Token::Default | Token::Break | Token::Continue | Token::Do
+            Token::Default | Token::Break | Token::Continue | Token::Do |
+            Token::Try | Token::Catch
         )
     }
     
@@ -115,7 +135,8 @@ impl Token {
         matches!(self,
             Token::Equals | Token::Plus | Token::Minus | Token::Multiply |
             Token::Divide | Token::Dot | Token::Colon | Token::QuestionMark |
-            Token::NullCoalescing | Token::Arrow | Token::Increment | Token::Decrement
+            Token::NullCoalescing | Token::Arrow | Token::Increment | Token::Decrement |
+            Token::LogicalAnd | Token::LogicalOr | Token::Ampersand | Token::Pipe
         )
     }
     
@@ -149,6 +170,13 @@ impl std::fmt::Display for Token {
             Token::NullCoalescing => write!(f, "??"),
             Token::Increment => write!(f, "++"),
             Token::Decrement => write!(f, "--"),
+            Token::At => write!(f, "@"),
+            Token::Ampersand => write!(f, "&"),
+            Token::Pipe => write!(f, "|"),
+            Token::LogicalAnd => write!(f, "&&"),
+            Token::LogicalOr => write!(f, "||"),
+            Token::Ellipsis => write!(f, "..."),
+            Token::Declare => write!(f, "declare"),
             Token::Semicolon => write!(f, ";"),
             Token::OpenParen => write!(f, "("),
             Token::CloseParen => write!(f, ")"),

--- a/crates/php-parser/src/ast/operator.rs
+++ b/crates/php-parser/src/ast/operator.rs
@@ -33,6 +33,12 @@ pub enum BinaryOp {
     LogicalAnd,
     /// Logical OR: ||
     LogicalOr,
+    /// Spaceship: <=>
+    Spaceship,
+    /// Bitwise AND: &
+    BitwiseAnd,
+    /// Bitwise OR: |
+    BitwiseOr,
 }
 
 /// Unary operators
@@ -60,10 +66,12 @@ impl BinaryOp {
             BinaryOp::LogicalAnd => 2,
             BinaryOp::Equal | BinaryOp::NotEqual => 3,
             BinaryOp::LessThan | BinaryOp::LessThanOrEqual | 
-            BinaryOp::GreaterThan | BinaryOp::GreaterThanOrEqual => 4,
-            BinaryOp::Concatenate => 5,
-            BinaryOp::Add | BinaryOp::Subtract => 6,
-            BinaryOp::Multiply | BinaryOp::Divide | BinaryOp::Modulo => 7,
+            BinaryOp::GreaterThan | BinaryOp::GreaterThanOrEqual | BinaryOp::Spaceship => 4,
+            BinaryOp::BitwiseAnd => 5,
+            BinaryOp::BitwiseOr => 5, // treat same precedence for simplified implementation
+            BinaryOp::Concatenate => 6,
+            BinaryOp::Add | BinaryOp::Subtract => 7,
+            BinaryOp::Multiply | BinaryOp::Divide | BinaryOp::Modulo => 8,
         }
     }
     
@@ -90,6 +98,9 @@ impl fmt::Display for BinaryOp {
             BinaryOp::GreaterThanOrEqual => ">=",
             BinaryOp::LogicalAnd => "&&",
             BinaryOp::LogicalOr => "||",
+            BinaryOp::Spaceship => "<=>",
+            BinaryOp::BitwiseAnd => "&",
+            BinaryOp::BitwiseOr => "|",
         };
         write!(f, "{}", op)
     }

--- a/crates/php-parser/src/parser/expressions.rs
+++ b/crates/php-parser/src/parser/expressions.rs
@@ -51,6 +51,11 @@ impl ExpressionParser {
                 Some(Token::GreaterThan) => BinaryOp::GreaterThan,
                 Some(Token::LessOrEqual) => BinaryOp::LessThanOrEqual,
                 Some(Token::GreaterOrEqual) => BinaryOp::GreaterThanOrEqual,
+                Some(Token::Spaceship) => BinaryOp::Spaceship,
+                Some(Token::Ampersand) => BinaryOp::BitwiseAnd,
+                Some(Token::Pipe) => BinaryOp::BitwiseOr,
+                Some(Token::LogicalAnd) => BinaryOp::LogicalAnd,
+                Some(Token::LogicalOr) => BinaryOp::LogicalOr,
                 Some(Token::NullCoalescing) => BinaryOp::Concatenate, // placeholder not real; null coalescing handled separately
                 _ => break,
             };
@@ -84,6 +89,85 @@ impl ExpressionParser {
             };
         }
 
+        // Ternary operator: condition ? then : else  (with shorthand condition ?: else)
+        if let Some(Token::QuestionMark) = tokens.peek() {
+            super::utils::ParserUtils::next_token(tokens, position); // consume '?'
+            let then_part = if let Some(Token::Colon) = tokens.peek() {
+                // Shorthand form 'expr ?: else'
+                None
+            } else {
+                Some(Box::new(Self::parse_expression_precedence(tokens, position, 0)?))
+            };
+            // Expect ':'
+            Self::consume_token(tokens, position, Token::Colon)?;
+            let else_expr = Self::parse_expression_precedence(tokens, position, 0)?;
+            left = Expr::Ternary {
+                condition: Box::new(left),
+                then_expr: then_part,
+                else_expr: Box::new(else_expr),
+            };
+        }
+
+        // match expression: match (expr) { condList => result, default => result }
+        if let Some(Token::Identifier(id)) = tokens.peek().cloned() {
+            if id == "match" {
+                super::utils::ParserUtils::next_token(tokens, position); // 'match'
+                Self::consume_token(tokens, position, Token::OpenParen)?;
+                let subject = Self::parse_expression(tokens, position)?;
+                Self::consume_token(tokens, position, Token::CloseParen)?;
+                Self::consume_token(tokens, position, Token::OpenBrace)?;
+                let mut arms: Vec<(Vec<Expr>, Box<Expr>)> = Vec::new();
+                let mut default_arm: Option<Box<Expr>> = None;
+                while let Some(tok) = tokens.peek() {
+                    if matches!(tok, Token::CloseBrace) { break; }
+                    // default arm (Token::Default or identifier "default")
+                    match tokens.peek().cloned() {
+                        Some(Token::Default) => {
+                            super::utils::ParserUtils::next_token(tokens, position); // default
+                            Self::consume_token(tokens, position, Token::Arrow)?;
+                            let result_expr = Self::parse_expression(tokens, position)?;
+                            default_arm = Some(Box::new(result_expr));
+                            if let Some(Token::Comma) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                            continue;
+                        }
+                        Some(Token::Identifier(d)) if d == "default" => {
+                            super::utils::ParserUtils::next_token(tokens, position);
+                            Self::consume_token(tokens, position, Token::Arrow)?;
+                            let result_expr = Self::parse_expression(tokens, position)?;
+                            default_arm = Some(Box::new(result_expr));
+                            if let Some(Token::Comma) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                            continue;
+                        }
+                        _ => {}
+                    }
+                    // parse one or more conditions separated by commas until '=>'
+                    let mut conds = Vec::new();
+                    loop {
+                        let cond_expr = Self::parse_expression(tokens, position)?;
+                        conds.push(cond_expr);
+                        if let Some(Token::Comma) = tokens.peek() { // could be separator between conditions or end of arm
+                            // lookahead to see if Arrow follows next
+                            let mut la = tokens.clone();
+                            la.next(); // consume comma in lookahead
+                            if let Some(Token::Arrow) = la.peek() {
+                                super::utils::ParserUtils::next_token(tokens, position); // consume comma and break
+                                break;
+                            } else {
+                                super::utils::ParserUtils::next_token(tokens, position); // consume comma continue
+                                continue;
+                            }
+                        }
+                        break;
+                    }
+                    Self::consume_token(tokens, position, Token::Arrow)?;
+                    let result_expr = Self::parse_expression(tokens, position)?;
+                    arms.push((conds, Box::new(result_expr)));
+                    if let Some(Token::Comma) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                }
+                Self::consume_token(tokens, position, Token::CloseBrace)?;
+                return Ok(Expr::Match { subject: Box::new(subject), arms, default_arm });
+            }
+        }
         Ok(left)
     }
 
@@ -92,11 +176,237 @@ impl ExpressionParser {
         tokens: &mut Peekable<IntoIter<Token>>,
         position: &mut usize,
     ) -> ParseResult<Expr> {
+        // Transparent reference prefix '&' (ignored semantics for now)
+        if let Some(Token::Ampersand) = tokens.peek() {
+            super::utils::ParserUtils::next_token(tokens, position); // consume '&'
+            // Parse the next primary and return directly (no reference semantics implemented)
+            return Self::parse_primary(tokens, position);
+        }
+        // Prefix increment/decrement
+        if let Some(Token::Increment) = tokens.peek() {
+            super::utils::ParserUtils::next_token(tokens, position); // '++'
+            let operand = Self::parse_primary(tokens, position)?;
+            return Ok(Expr::Unary { op: crate::ast::UnaryOp::PreIncrement, operand: Box::new(operand) });
+        }
+        if let Some(Token::Decrement) = tokens.peek() {
+            super::utils::ParserUtils::next_token(tokens, position); // '--'
+            let operand = Self::parse_primary(tokens, position)?;
+            return Ok(Expr::Unary { op: crate::ast::UnaryOp::PreDecrement, operand: Box::new(operand) });
+        }
+        // Anonymous function: function (...) { ... }
+        if let Some(Token::Function) = tokens.peek() {
+            super::utils::ParserUtils::next_token(tokens, position); // consume 'function'
+            // Optional name (if present treat as normal function? we only allow anonymous here, so if Identifier next and then '(' treat as named fallback error)
+            if let Some(Token::Identifier(_)) = tokens.peek() {
+                // Fallback: not anonymous, push error to caller
+            }
+            // Parameter list
+            Self::consume_token(tokens, position, Token::OpenParen)?;
+            let mut params = Vec::new();
+            if let Some(Token::CloseParen) = tokens.peek() {
+                super::utils::ParserUtils::next_token(tokens, position); // empty param list
+            } else {
+                loop {
+                    // Skip type hints (identifiers + pipes)
+                    loop { match tokens.peek() { Some(Token::Identifier(_)) => { super::utils::ParserUtils::next_token(tokens, position); }, _ => break } if let Some(Token::Pipe) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); continue; } else { break; } }
+                    if let Some(Token::Ellipsis) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                    // Optional by-reference '&'
+                    if let Some(Token::Ampersand) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                    let var_name = match super::utils::ParserUtils::next_token(tokens, position) { Some(Token::Variable(v)) => v, other => return Err(ParseError::ExpectedToken { expected: "parameter variable".into(), found: format!("{:?}", other), position: *position }) };
+                    if let Some(Token::Equals) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); let _ = Self::parse_expression(tokens, position)?; }
+                    params.push(var_name);
+                    match tokens.peek() { Some(Token::Comma) => { super::utils::ParserUtils::next_token(tokens, position); }, Some(Token::CloseParen) => { super::utils::ParserUtils::next_token(tokens, position); break; }, other => return Err(ParseError::ExpectedToken { expected: ", or )".into(), found: format!("{:?}", other), position: *position }) }
+                }
+            }
+            // Optional return type: ':' identifiers and pipes
+            if let Some(Token::Colon) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); while let Some(Token::Identifier(_)) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); if let Some(Token::Pipe) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); continue; } break; } }
+            // Body block
+            Self::consume_token(tokens, position, Token::OpenBrace)?;
+            // Collect statements until closing brace, but we simplify: parse as block, then wrap in implicit return of last expression if it is an expression statement
+            let mut body_stmts = Vec::new();
+            while let Some(tk) = tokens.peek() { if matches!(tk, Token::CloseBrace) { break; } body_stmts.push(super::main::Parser::parse_statement_with_tokens(tokens, position)?); }
+            Self::consume_token(tokens, position, Token::CloseBrace)?;
+            // Heuristic: if last statement is Expression(e) produce closure body expression = e; else null
+            let body_expr = if let Some(last) = body_stmts.last() { if let crate::ast::Stmt::Expression(e) = last { e.clone() } else { Expr::Null } } else { Expr::Null };
+            return Ok(Expr::ArrowFunction { params, body: Box::new(body_expr) });
+        }
+        // Arrow function start: identifier 'fn'
+        if let Some(Token::Identifier(name)) = tokens.peek().cloned() {
+            if name == "fn" {
+                super::utils::ParserUtils::next_token(tokens, position); // consume 'fn'
+                // Expect '('
+                Self::consume_token(tokens, position, Token::OpenParen)?;
+                let mut params = Vec::new();
+                // Parse param list (possibly empty) skipping type hints (identifiers and pipes) until variable appears
+                if let Some(token) = tokens.peek() {
+                    if let Token::CloseParen = token { super::utils::ParserUtils::next_token(tokens, position); } else {
+                        loop {
+                            // Skip simple type hints (Identifier ('|' Identifier)*)
+                            loop {
+                                match tokens.peek() {
+                                    Some(Token::Identifier(_)) => { super::utils::ParserUtils::next_token(tokens, position); }
+                                    _ => break,
+                                }
+                                if let Some(Token::Pipe) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); continue; } else { break; }
+                            }
+                            // Variadic/spread ellipsis (ignored semantics)
+                            if let Some(Token::Ellipsis) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                            // Optional by-reference '&'
+                            if let Some(Token::Ampersand) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                            // Expect variable name
+                            let var_name = match super::utils::ParserUtils::next_token(tokens, position) {
+                                Some(Token::Variable(v)) => v,
+                                other => return Err(ParseError::ExpectedToken { expected: "parameter variable".into(), found: format!("{:?}", other), position: *position }),
+                            };
+                            // Optional default value assign skip: '=' expr
+                            if let Some(Token::Equals) = tokens.peek() {
+                                super::utils::ParserUtils::next_token(tokens, position);
+                                let _ = Self::parse_expression(tokens, position)?; // discard
+                            }
+                            params.push(var_name);
+                            match tokens.peek() {
+                                Some(Token::Comma) => { super::utils::ParserUtils::next_token(tokens, position); continue; }
+                                Some(Token::CloseParen) => { super::utils::ParserUtils::next_token(tokens, position); break; }
+                                other => return Err(ParseError::ExpectedToken { expected: ", or )".into(), found: format!("{:?}", other), position: *position }),
+                            }
+                        }
+                    }
+                }
+                // Expect => (represented as Arrow token? we currently have Token::Arrow for '=>')
+                Self::consume_token(tokens, position, Token::Arrow)?;
+                let body = Self::parse_expression(tokens, position)?;
+                return Ok(Expr::ArrowFunction { params, body: Box::new(body) });
+            }
+        }
+        // Match expression starting directly (e.g., = match (...){...};)
+        if let Some(Token::Identifier(name)) = tokens.peek().cloned() {
+            if name == "match" {
+                super::utils::ParserUtils::next_token(tokens, position); // 'match'
+                Self::consume_token(tokens, position, Token::OpenParen)?;
+                let subject = Self::parse_expression(tokens, position)?;
+                Self::consume_token(tokens, position, Token::CloseParen)?;
+                Self::consume_token(tokens, position, Token::OpenBrace)?;
+                let mut arms: Vec<(Vec<Expr>, Box<Expr>)> = Vec::new();
+                let mut default_arm: Option<Box<Expr>> = None;
+                while let Some(tok) = tokens.peek() {
+                    if matches!(tok, Token::CloseBrace) { break; }
+                    match tokens.peek().cloned() {
+                        Some(Token::Default) => {
+                            super::utils::ParserUtils::next_token(tokens, position);
+                            Self::consume_token(tokens, position, Token::Arrow)?;
+                            let res = Self::parse_expression(tokens, position)?;
+                            default_arm = Some(Box::new(res));
+                            if let Some(Token::Comma) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                            continue;
+                        }
+                        Some(Token::Identifier(d)) if d == "default" => {
+                            super::utils::ParserUtils::next_token(tokens, position);
+                            Self::consume_token(tokens, position, Token::Arrow)?;
+                            let res = Self::parse_expression(tokens, position)?;
+                            default_arm = Some(Box::new(res));
+                            if let Some(Token::Comma) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                            continue;
+                        }
+                        _ => {}
+                    }
+                    let mut conds = Vec::new();
+                    loop {
+                        let cond_expr = Self::parse_expression(tokens, position)?;
+                        conds.push(cond_expr);
+                        if let Some(Token::Comma) = tokens.peek() { // lookahead for arrow after comma
+                            let mut la = tokens.clone(); la.next(); if let Some(Token::Arrow) = la.peek() { super::utils::ParserUtils::next_token(tokens, position); break; } else { super::utils::ParserUtils::next_token(tokens, position); continue; } }
+                        break;
+                    }
+                    Self::consume_token(tokens, position, Token::Arrow)?;
+                    let result_expr = Self::parse_expression(tokens, position)?;
+                    arms.push((conds, Box::new(result_expr)));
+                    if let Some(Token::Comma) = tokens.peek() { super::utils::ParserUtils::next_token(tokens, position); }
+                }
+                Self::consume_token(tokens, position, Token::CloseBrace)?;
+                return Ok(Expr::Match { subject: Box::new(subject), arms, default_arm });
+            }
+        }
+        // Yield expression (identifier 'yield' not a keyword yet)
+        if let Some(Token::Identifier(name)) = tokens.peek().cloned() {
+            if name == "yield" {
+                super::utils::ParserUtils::next_token(tokens, position); // 'yield'
+                // Optional 'from'
+                if let Some(Token::Identifier(n2)) = tokens.peek().cloned() { if n2 == "from" { super::utils::ParserUtils::next_token(tokens, position); } }
+                let inner = Self::parse_expression(tokens, position)?; // value expression
+                return Ok(Expr::Yield { value: Box::new(inner) });
+            }
+        }
         match super::utils::ParserUtils::next_token(tokens, position) {
             Some(Token::Number(n)) => Ok(Expr::Number(n)),
             Some(Token::String(s)) => Ok(Expr::String(s)),
-            Some(Token::Variable(name)) => Ok(Expr::Variable(name)),
+            Some(Token::Variable(name)) => {
+                // Pattern: $var(...)
+                if let Some(Token::OpenParen) = tokens.peek() {
+                    let mut clone_iter = tokens.clone();
+                    let open = clone_iter.next();
+                    let maybe_ellipsis = clone_iter.next();
+                    let maybe_close = clone_iter.next();
+                    if matches!(open, Some(Token::OpenParen)) && matches!(maybe_ellipsis, Some(Token::Ellipsis)) && matches!(maybe_close, Some(Token::CloseParen)) {
+                        // consume actual tokens
+                        super::utils::ParserUtils::next_token(tokens, position); // '('
+                        super::utils::ParserUtils::next_token(tokens, position); // '...'
+                        super::utils::ParserUtils::next_token(tokens, position); // ')'
+                        return Ok(Expr::Variable(name));
+                    }
+                    // Dynamic call: $var(...args...)
+                    if let Some(Token::OpenParen) = tokens.peek() {
+                        super::utils::ParserUtils::next_token(tokens, position); // consume '('
+                        let args = Self::parse_function_args(tokens, position)?;
+                        Self::consume_token(tokens, position, Token::CloseParen)?;
+                        let call_expr = Expr::DynamicCall { target: Box::new(Expr::Variable(name.clone())), args };
+                        let call_expr = Self::parse_postfix_access(tokens, position, call_expr)?;
+                        return Ok(call_expr);
+                    }
+                }
+                Ok(Expr::Variable(name))
+            }
+            // Built-in function tokens: convert to identifier name for uniform handling
+            Some(Token::ArrayMerge) => Self::parse_builtin_as_call("array_merge".to_string(), tokens, position),
+            Some(Token::ArrayPush) => Self::parse_builtin_as_call("array_push".to_string(), tokens, position),
+            Some(Token::ArrayPop) => Self::parse_builtin_as_call("array_pop".to_string(), tokens, position),
+            Some(Token::Count) => Self::parse_builtin_as_call("count".to_string(), tokens, position),
+            Some(Token::Explode) => Self::parse_builtin_as_call("explode".to_string(), tokens, position),
+            Some(Token::Implode) => Self::parse_builtin_as_call("implode".to_string(), tokens, position),
+            Some(Token::PrintR) => Self::parse_builtin_as_call("print_r".to_string(), tokens, position),
+            Some(Token::Strlen) => Self::parse_builtin_as_call("strlen".to_string(), tokens, position),
+            Some(Token::Strpos) => Self::parse_builtin_as_call("strpos".to_string(), tokens, position),
+            Some(Token::Substr) => Self::parse_builtin_as_call("substr".to_string(), tokens, position),
+            Some(Token::Isset) => Self::parse_builtin_as_call("isset".to_string(), tokens, position),
             Some(Token::Identifier(name)) => {
+                if name == "array" {
+                    // Legacy array() constructor
+                    if let Some(Token::OpenParen) = tokens.peek() {
+                        super::utils::ParserUtils::next_token(tokens, position); // '('
+                        let mut elements = Vec::new();
+                        if let Some(Token::CloseParen) = tokens.peek() {
+                            super::utils::ParserUtils::next_token(tokens, position); // empty )
+                            return Ok(Expr::Array(elements));
+                        }
+                        loop {
+                            // Parse key or value expression
+                            let first_expr = Self::parse_expression(tokens, position)?;
+                            let element = if let Some(Token::Arrow) = tokens.peek() {
+                                super::utils::ParserUtils::next_token(tokens, position); // '=>'
+                                let val_expr = Self::parse_expression(tokens, position)?;
+                                crate::ast::ArrayElement { key: Some(first_expr), value: val_expr }
+                            } else {
+                                crate::ast::ArrayElement { key: None, value: first_expr }
+                            };
+                            elements.push(element);
+                            match tokens.peek() {
+                                Some(Token::Comma) => { super::utils::ParserUtils::next_token(tokens, position); }
+                                Some(Token::CloseParen) => { super::utils::ParserUtils::next_token(tokens, position); break; }
+                                other => return Err(ParseError::ExpectedToken { expected: ", or )".into(), found: format!("{:?}", other), position: *position }),
+                            }
+                        }
+                        return Ok(Expr::Array(elements));
+                    }
+                }
                 // Check if this is a function call (identifier followed by opening parenthesis)
                 if let Some(&Token::OpenParen) = tokens.peek() {
                     super::utils::ParserUtils::next_token(tokens, position); // consume opening parenthesis
@@ -115,6 +425,20 @@ impl ExpressionParser {
             Some(Token::False) => Ok(Expr::Bool(false)),
             Some(Token::Null) => Ok(Expr::Null),
             Some(Token::OpenParen) => {
+                // Look ahead for possible cast pattern: (Identifier) followed by expression
+                if let Some(Token::Identifier(cast_name)) = tokens.peek().cloned() {
+                    // Simple list of primitive casts we accept
+                    let primitive = matches!(cast_name.as_str(), "int" | "float" | "string" | "bool" | "boolean");
+                    if primitive {
+                        // consume identifier and closing paren, then parse the target expression
+                        super::utils::ParserUtils::next_token(tokens, position); // cast type
+                        Self::consume_token(tokens, position, Token::CloseParen)?;
+                        // After cast, allow immediate opening paren or primary expression
+                        let inner = Self::parse_expression(tokens, position)?;
+                        return Ok(inner); // ignore cast semantics for now
+                    }
+                }
+                // Regular parenthesized expression
                 let expr = Self::parse_expression(tokens, position)?;
                 Self::consume_token(tokens, position, Token::CloseParen)?;
                 Ok(expr)
@@ -131,6 +455,24 @@ impl ExpressionParser {
         }
     }
 
+    /// Helper to parse a built-in function token as potential function call or constant
+    fn parse_builtin_as_call(
+        name: String,
+        tokens: &mut Peekable<IntoIter<Token>>,
+        position: &mut usize,
+    ) -> ParseResult<Expr> {
+        if let Some(&Token::OpenParen) = tokens.peek() {
+            super::utils::ParserUtils::next_token(tokens, position); // consume '('
+            let args = Self::parse_function_args(tokens, position)?;
+            Self::consume_token(tokens, position, Token::CloseParen)?;
+            let call_expr = Expr::FunctionCall { name, args };
+            let call_expr = Self::parse_postfix_access(tokens, position, call_expr)?;
+            Ok(call_expr)
+        } else {
+            Ok(Expr::Constant(name))
+        }
+    }
+
     /// Parse function arguments
     fn parse_function_args(
         tokens: &mut Peekable<IntoIter<Token>>,
@@ -143,16 +485,47 @@ impl ExpressionParser {
             return Ok(args);
         }
 
-        // Parse first argument
-        args.push(Self::parse_expression(tokens, position)?);
+        // Parse first argument (support named args: Identifier ':' expr)
+    args.push(Self::parse_named_or_positional_arg(tokens, position)?);
 
         // Parse remaining arguments
         while let Some(&Token::Comma) = tokens.peek() {
             super::utils::ParserUtils::next_token(tokens, position); // consume comma
-            args.push(Self::parse_expression(tokens, position)?);
+            args.push(Self::parse_named_or_positional_arg(tokens, position)?);
         }
 
         Ok(args)
+    }
+
+    /// Parse either a named argument (Identifier ':' expr) or a standard expression argument.
+    fn parse_named_or_positional_arg(
+        tokens: &mut Peekable<IntoIter<Token>>,
+        position: &mut usize,
+    ) -> ParseResult<Expr> {
+        // Skip spread ellipsis (ignored semantics)
+        if let Some(Token::Ellipsis) = tokens.peek() {
+            super::utils::ParserUtils::next_token(tokens, position); // '...'
+        }
+        if let Some(Token::Identifier(_)) = tokens.peek() {
+            // Clone iterator to inspect following token
+            let mut clone_iter = tokens.clone();
+            let first = clone_iter.next();
+            let second = clone_iter.peek();
+            // Named arg pattern: name ':' expr
+            if matches!(first, Some(Token::Identifier(_))) && matches!(second, Some(Token::Colon)) {
+                super::utils::ParserUtils::next_token(tokens, position); // identifier
+                super::utils::ParserUtils::next_token(tokens, position); // colon
+                return Self::parse_expression(tokens, position);
+            }
+            // declare-style pattern: name '=' expr (treat as expression after '=' for now)
+            if matches!(first, Some(Token::Identifier(_))) && matches!(second, Some(Token::Equals)) {
+                // consume identifier and equals, parse expression
+                super::utils::ParserUtils::next_token(tokens, position); // identifier
+                super::utils::ParserUtils::next_token(tokens, position); // '='
+                return Self::parse_expression(tokens, position);
+            }
+        }
+        Self::parse_expression(tokens, position)
     }
 
     /// Get operator precedence
@@ -164,10 +537,13 @@ impl ExpressionParser {
             BinaryOp::LessThan
             | BinaryOp::GreaterThan
             | BinaryOp::LessThanOrEqual
-            | BinaryOp::GreaterThanOrEqual => 3,
-            BinaryOp::Concatenate => 4,
-            BinaryOp::Add | BinaryOp::Subtract => 5,
-            BinaryOp::Multiply | BinaryOp::Divide | BinaryOp::Modulo => 6,
+            | BinaryOp::GreaterThanOrEqual
+            | BinaryOp::Spaceship => 3,
+            BinaryOp::BitwiseAnd => 4,
+            BinaryOp::BitwiseOr => 4,
+            BinaryOp::Concatenate => 5,
+            BinaryOp::Add | BinaryOp::Subtract => 6,
+            BinaryOp::Multiply | BinaryOp::Divide | BinaryOp::Modulo => 7,
         }
     }
 
@@ -205,6 +581,10 @@ impl ExpressionParser {
 
         loop {
             // Parse the value expression
+            // Support spread '...expr' (ignored flattening semantics; treat as normal expression)
+            if let Some(Token::Ellipsis) = tokens.peek() {
+                super::utils::ParserUtils::next_token(tokens, position); // consume '...'
+            }
             let value = Self::parse_expression(tokens, position)?;
 
             // Check if this is a key-value pair (key => value)
@@ -284,6 +664,37 @@ impl ExpressionParser {
                         array: Box::new(expr),
                         index: Box::new(index_expr),
                     };
+                }
+                Some(Token::ObjectOperator) => {
+                    super::utils::ParserUtils::next_token(tokens, position); // '->'
+                    // Expect identifier for method/property
+                    let name = match super::utils::ParserUtils::next_token(tokens, position) {
+                        Some(Token::Identifier(id)) => id,
+                        other => return Err(ParseError::ExpectedToken { expected: "method name".into(), found: format!("{:?}", other), position: *position })
+                    };
+                    // Optional call
+                    if let Some(Token::OpenParen) = tokens.peek() {
+                        super::utils::ParserUtils::next_token(tokens, position); // '('
+                        // parse args until ')'
+                        let mut args = Vec::new();
+                        if let Some(Token::CloseParen) = tokens.peek() {
+                            super::utils::ParserUtils::next_token(tokens, position); // empty
+                        } else {
+                            loop {
+                                let arg = Self::parse_expression(tokens, position)?;
+                                args.push(arg);
+                                match tokens.peek() {
+                                    Some(Token::Comma) => { super::utils::ParserUtils::next_token(tokens, position); }
+                                    Some(Token::CloseParen) => { super::utils::ParserUtils::next_token(tokens, position); break; }
+                                    other => return Err(ParseError::ExpectedToken { expected: ", or )".into(), found: format!("{:?}", other), position: *position }),
+                                }
+                            }
+                        }
+                        expr = Expr::MethodCall { target: Box::new(expr), method: name, args };
+                    } else {
+                        // Property fetch fallback: treat as zero-arg method call
+                        expr = Expr::MethodCall { target: Box::new(expr), method: name, args: Vec::new() };
+                    }
                 }
                 _ => break,
             }

--- a/crates/php-parser/src/parser/main.rs
+++ b/crates/php-parser/src/parser/main.rs
@@ -71,6 +71,8 @@ impl Parser {
             Some(Token::Echo) => StatementParser::parse_echo(tokens, position),
             Some(Token::Print) => StatementParser::parse_print(tokens, position),
             Some(Token::Variable(_)) => StatementParser::parse_assignment_or_expression(tokens, position),
+            Some(Token::OpenBracket) => StatementParser::parse_assignment_or_expression(tokens, position),
+            Some(Token::Static) => StatementParser::parse_static(tokens, position),
             Some(Token::Const) => StatementParser::parse_const(tokens, position),
             Some(Token::Function) => StatementParser::parse_function_definition(tokens, position),
             Some(Token::If) => ControlFlowParser::parse_if(tokens, position),
@@ -81,6 +83,8 @@ impl Parser {
             Some(Token::Break) => ControlFlowParser::parse_break(tokens, position),
             Some(Token::Continue) => ControlFlowParser::parse_continue(tokens, position),
             Some(Token::Switch) => ControlFlowParser::parse_switch(tokens, position),
+            Some(Token::Try) => ControlFlowParser::parse_try(tokens, position),
+            Some(Token::Declare) => StatementParser::parse_declare(tokens, position),
             Some(Token::OpenBrace) => Self::parse_block_statement(tokens, position),
             _ => StatementParser::parse_expression_statement(tokens, position),
         }

--- a/crates/php-runtime/Cargo.toml
+++ b/crates/php-runtime/Cargo.toml
@@ -11,7 +11,9 @@ description = ""
 [dependencies]
 # Add crate-specific dependencies here
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 php-types = { path = "../php-types" }
 php-parser = { path = "../php-parser" }
+regex.workspace = true
 


### PR DESCRIPTION
This update introduces heredoc and nowdoc string literal lexing, adds tokens for spaceship operator, logical and bitwise operators, object operator, ellipsis, and error suppression. The parser and AST now support ternary and match expressions, null coalescing assignment, destructuring assignment, static variables, closures/arrow functions, dynamic calls, yield, and method calls. The README is updated to reflect new features, limitations, and development focus.